### PR TITLE
Turn off or on forward slash escaping on an already created JSONObject.

### DIFF
--- a/src/main/java/org/codehaus/jettison/json/JSONObject.java
+++ b/src/main/java/org/codehaus/jettison/json/JSONObject.java
@@ -143,6 +143,8 @@ public class JSONObject implements Serializable {
     private List ignoredElements;
     private boolean writeNullAsString = true;
     private boolean escapeForwardSlashAlways = true;
+
+
     /**
      * It is sometimes more convenient and less ambiguous to have a
      * <code>NULL</code> object than to use Java's <code>null</code> value.
@@ -1384,5 +1386,13 @@ public class JSONObject implements Serializable {
         } catch (IOException e) {
             throw new JSONException(e);
         }
+     }
+     
+     public boolean isEscapeForwardSlashAlways() {
+       return escapeForwardSlashAlways;
+     }
+
+     public void setEscapeForwardSlashAlways(boolean escapeForwardSlashAlways) {
+       this.escapeForwardSlashAlways = escapeForwardSlashAlways;
      }
 }

--- a/src/test/java/org/codehaus/jettison/json/JSONObjectTest.java
+++ b/src/test/java/org/codehaus/jettison/json/JSONObjectTest.java
@@ -77,4 +77,20 @@ public class JSONObjectTest extends TestCase {
         JSONObject obj = new JSONObject("{\"a\":null}");
         assertTrue(obj.isNull("b"));
     }
+    
+    public void testSlashEscapingTurnedOnByDefault() throws Exception {
+       JSONObject obj = new JSONObject();
+       obj.put("key", "http://example.com/foo");
+       assertEquals(obj.toString(), "{\"key\":\"http:\\/\\/example.com\\/foo\"}");
+    }
+    
+    public void testForwardSlashEscapingModifiedfBySetter() throws Exception {
+      JSONObject obj = new JSONObject();
+      obj.put("key", "http://example.com/foo");
+      assertEquals(obj.toString(), "{\"key\":\"http:\\/\\/example.com\\/foo\"}");
+      obj.setEscapeForwardSlashAlways(false);
+      assertEquals(obj.toString(), "{\"key\":\"http://example.com/foo\"}");
+      obj.setEscapeForwardSlashAlways(true);
+      assertEquals(obj.toString(), "{\"key\":\"http:\\/\\/example.com\\/foo\"}");
+   }
 }


### PR DESCRIPTION
This modification is a solution for issue #2 I created for jettison.
It is actually a setter which can be set on a JSON object to turn off or on the forward slash escaping.
I included two tests as well.
